### PR TITLE
Add phoneme override and dictionary support with timestamp alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "clap",
  "kokoros",
  "kokoros-openai",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/koko/Cargo.toml
+++ b/koko/Cargo.toml
@@ -11,3 +11,4 @@ clap = { version = "4.5.39", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["io-util", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+serde_json = "1.0"

--- a/koko/src/main.rs
+++ b/koko/src/main.rs
@@ -144,6 +144,10 @@ struct Cli {
     #[arg(long = "initial-silence", value_name = "INITIAL_SILENCE")]
     initial_silence: Option<usize>,
 
+    /// Path to a JSON dictionary file for phoneme overrides
+    #[arg(long = "dict", value_name = "DICT_PATH")]
+    dict_path: Option<String>,
+
     /// Also output a sidecar TSV file with word-level timestamps
     #[arg(long = "timestamps", default_value_t = false, global = true)]
     timestamps: bool,
@@ -260,13 +264,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             style,
             speed,
             initial_silence,
+            dict_path,
             mono,
             timestamps,
             instances,
             mode,
         } = Cli::parse();
 
-        let tts = TTSKoko::new(&model_path, &data_path).await;
+        let mut tts = TTSKoko::new(&model_path, &data_path).await;
+
+        let phoneme_map = if let Some(dict_path) = &dict_path {
+            let dict_content = fs::read_to_string(dict_path)?;
+            let map: std::collections::HashMap<String, String> = serde_json::from_str(&dict_content)?;
+            Some(std::sync::Arc::new(kokoros::tts::phonemizer::PhonemeMap::new(map)))
+        } else {
+            None
+        };
+
+        if let Some(map) = &phoneme_map {
+            tts = tts.with_phoneme_map(std::sync::Arc::clone(map));
+        }
 
         match mode {
             Mode::File {
@@ -386,7 +403,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         i + 1,
                         instances
                     );
-                    let instance = TTSKoko::new(&model_path, &data_path).await;
+                    let mut instance = TTSKoko::new(&model_path, &data_path).await;
+                    if let Some(map) = &phoneme_map {
+                        instance = instance.with_phoneme_map(std::sync::Arc::clone(map));
+                    }
                     tts_instances.push(instance);
                 }
                 let app = kokoros_openai::create_server(tts_instances).await;

--- a/kokoros-openai/src/lib.rs
+++ b/kokoros-openai/src/lib.rs
@@ -34,6 +34,7 @@ use axum::{
 use futures::stream::StreamExt;
 use kokoros::{
     tts::koko::{InitConfig as TTSKokoInitConfig, TTSKoko},
+    tts::phonemizer::PhonemeMap,
     utils::mp3::pcm_to_mp3,
     utils::opus::pcm_to_opus_ogg,
     utils::wav::{WavHeader, write_audio_chunk},
@@ -350,6 +351,9 @@ struct SpeechRequest {
     #[serde(default)]
     stream: Option<bool>,
 
+    #[serde(default)]
+    phonemes: Option<std::collections::HashMap<String, String>>,
+
     // OpenAI API compatibility parameters - accepted but not implemented
     // These fields ensure request parsing compatibility with OpenAI clients
     /// Return download link after generation (not implemented)
@@ -543,6 +547,7 @@ async fn handle_tts(
         speed: Speed(speed),
         initial_silence,
         stream,
+        phonemes,
         ..
     } = speech_request;
 
@@ -558,6 +563,18 @@ async fn handle_tts(
         colored_request_id, stream, should_stream
     );
 
+    // Handle per-request phoneme map
+    let mut tts_single = tts_single.clone();
+    if let Some(req_phonemes) = phonemes {
+        let mut final_map = if let Some(global_map) = &tts_single.phoneme_map {
+            global_map.as_ref().map.clone()
+        } else {
+            std::collections::HashMap::new()
+        };
+        final_map.extend(req_phonemes);
+        tts_single = tts_single.with_phoneme_map(Arc::new(PhonemeMap::new(final_map)));
+    }
+
     if should_stream {
         return handle_tts_streaming(
             tts_instances,
@@ -568,6 +585,7 @@ async fn handle_tts(
             initial_silence,
             request_id,
             request_start,
+            tts_single.phoneme_map.clone(),
         )
         .await;
     }
@@ -659,6 +677,7 @@ async fn handle_tts_streaming(
     initial_silence: Option<usize>,
     request_id: String,
     request_start: Instant,
+    phoneme_map: Option<Arc<PhonemeMap>>,
 ) -> Result<Response, SpeechError> {
     // Streaming implementation: PCM format for optimal performance
     let content_type = match response_format {
@@ -756,8 +775,16 @@ async fn handle_tts_streaming(
                         let request_id_clone = request_id.clone();
 
                         // Process chunk with dedicated TTS instance (alternates between instances)
-                        let (tts_instance, actual_instance_id) =
+                        let (mut tts_instance, actual_instance_id) =
                             worker_pool_clone.get_instance(chunk_counter);
+
+                        // Wrap with per-request phoneme map if provided
+                        if let Some(map) = phoneme_map.clone() {
+                            let mut tts_wrapped = tts_instance.as_ref().clone();
+                            tts_wrapped = tts_wrapped.with_phoneme_map(map);
+                            tts_instance = Arc::new(tts_wrapped);
+                        }
+
                         let chunk_text = task.chunk.clone();
                         let voice = task.voice.clone();
                         let speed = task.speed;

--- a/kokoros/examples/multi_client_dictionaries.rs
+++ b/kokoros/examples/multi_client_dictionaries.rs
@@ -1,0 +1,52 @@
+use kokoros::tts::koko::TTSKoko;
+use kokoros::tts::phonemizer::PhonemeMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Setup global TTS with a shared dictionary
+    let mut global_dict = HashMap::new();
+    global_dict.insert("Kokoro".to_string(), "kˈoʊkəɹoʊ".to_string());
+    let global_map = Arc::new(PhonemeMap::new(global_dict));
+
+    // Initializing TTSKoko once is expensive, but cloning it later is cheap.
+    let tts = TTSKoko::new("checkpoints/kokoro-v1.0.onnx", "data/voices-v1.0.bin")
+        .await
+        .with_phoneme_map(global_map);
+
+    // 2. Simulate Client A with its own dictionary
+    let mut client_a_dict = HashMap::new();
+    client_a_dict.insert("Rust".to_string(), "ɹˈʌst".to_string());
+
+    // To efficiently handle per-client dictionaries:
+    // a) Merge with global dict if needed
+    let mut merged_a = tts.phoneme_map.as_ref().map(|m| m.map.clone()).unwrap_or_default();
+    merged_a.extend(client_a_dict);
+    let map_a = Arc::new(PhonemeMap::new(merged_a));
+
+    // b) Create a lightweight wrapper for this request
+    let tts_a = tts.clone().with_phoneme_map(map_a);
+
+    // 3. Simulate Client B with its own dictionary
+    let mut client_b_dict = HashMap::new();
+    client_b_dict.insert("Fast".to_string(), "fˈæst".to_string());
+
+    let mut merged_b = tts.phoneme_map.as_ref().map(|m| m.map.clone()).unwrap_or_default();
+    merged_b.extend(client_b_dict);
+    let map_b = Arc::new(PhonemeMap::new(merged_b));
+
+    let tts_b = tts.clone().with_phoneme_map(map_b);
+
+    // Now tts_a and tts_b share the same model and style data (Arc-wrapped),
+    // but have different phoneme maps.
+
+    println!("Client A map entries: {:?}", tts_a.phoneme_map.as_ref().unwrap().map.keys());
+    println!("Client B map entries: {:?}", tts_b.phoneme_map.as_ref().unwrap().map.keys());
+
+    // Synthesis calls would go here:
+    // tts_a.tts_raw_audio("Kokoro is written in Rust", ...);
+    // tts_b.tts_raw_audio("Kokoro is insanely Fast", ...);
+
+    Ok(())
+}

--- a/kokoros/src/tts/koko.rs
+++ b/kokoros/src/tts/koko.rs
@@ -62,7 +62,7 @@ pub struct TTSKoko {
     #[allow(dead_code)]
     model_path: String,
     model: Arc<Mutex<ort_koko::OrtKoko>>,
-    styles: HashMap<String, Vec<[[f32; 256]; 1]>>,
+    styles: Arc<HashMap<String, Vec<[[f32; 256]; 1]>>>,
     pub phoneme_map: Option<Arc<PhonemeMap>>,
     init_config: InitConfig,
 }
@@ -73,7 +73,7 @@ pub struct TTSKokoParallel {
     #[allow(dead_code)]
     model_path: String,
     models: Vec<Arc<Mutex<ort_koko::OrtKoko>>>,
-    styles: HashMap<String, Vec<[[f32; 256]; 1]>>,
+    styles: Arc<HashMap<String, Vec<[[f32; 256]; 1]>>>,
     pub phoneme_map: Option<Arc<PhonemeMap>>,
     init_config: InitConfig,
 }
@@ -878,7 +878,7 @@ impl TTSKoko {
         tokens_len: usize,
     ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error>> {
         if !style_name.contains("+") {
-            if let Some(style) = self.styles.get(style_name) {
+            if let Some(style) = self.styles.as_ref().get(style_name) {
                 let styles = vec![style[tokens_len][0].to_vec()];
                 Ok(styles)
             } else {
@@ -904,7 +904,7 @@ impl TTSKoko {
             let mut blended_style = vec![vec![0.0; 256]; 1];
 
             for (name, portion) in style_names.iter().zip(style_portions.iter()) {
-                if let Some(style) = self.styles.get(*name) {
+                if let Some(style) = self.styles.as_ref().get(*name) {
                     let style_slice = &style[tokens_len][0]; // This is a [256] array
                     // Blend into the blended_style
                     for j in 0..256 {
@@ -917,7 +917,7 @@ impl TTSKoko {
         }
     }
 
-    fn load_voices(voices_path: &str) -> HashMap<String, Vec<[[f32; 256]; 1]>> {
+    fn load_voices(voices_path: &str) -> Arc<HashMap<String, Vec<[[f32; 256]; 1]>>> {
         let mut npz = NpzReader::new(File::open(voices_path).unwrap()).unwrap();
         let mut map = HashMap::new();
 
@@ -990,12 +990,12 @@ impl TTSKoko {
             voices
         };
 
-        map
+        Arc::new(map)
     }
 
     // Returns a sorted list of available voice names
     pub fn get_available_voices(&self) -> Vec<String> {
-        let mut voices: Vec<String> = self.styles.keys().cloned().collect();
+        let mut voices: Vec<String> = self.styles.as_ref().keys().cloned().collect();
         voices.sort();
         voices
     }
@@ -1077,7 +1077,6 @@ impl TTSKokoParallel {
         TTSKoko {
             model_path: self.model_path.clone(),
             model: model_instance,
-            // TODO: This clones the HashMap. In a future PR, wrap styles in Arc<>!
             styles: self.styles.clone(),
             phoneme_map: self.phoneme_map.clone(),
             init_config: self.init_config.clone(),

--- a/kokoros/src/tts/koko.rs
+++ b/kokoros/src/tts/koko.rs
@@ -1,5 +1,5 @@
 use crate::onn::ort_koko::{self, ModelStrategy};
-use crate::tts::phonemizer::Phonemizer;
+use crate::tts::phonemizer::{Phonemizer, PhonemeMap};
 use crate::tts::tokenize::tokenize;
 use crate::utils;
 use crate::utils::debug::format_debug_prefix;
@@ -63,6 +63,7 @@ pub struct TTSKoko {
     model_path: String,
     model: Arc<Mutex<ort_koko::OrtKoko>>,
     styles: HashMap<String, Vec<[[f32; 256]; 1]>>,
+    pub phoneme_map: Option<Arc<PhonemeMap>>,
     init_config: InitConfig,
 }
 
@@ -73,6 +74,7 @@ pub struct TTSKokoParallel {
     model_path: String,
     models: Vec<Arc<Mutex<ort_koko::OrtKoko>>>,
     styles: HashMap<String, Vec<[[f32; 256]; 1]>>,
+    pub phoneme_map: Option<Arc<PhonemeMap>>,
     init_config: InitConfig,
 }
 
@@ -124,8 +126,14 @@ impl TTSKoko {
             model_path: model_path.to_string(),
             model,
             styles,
+            phoneme_map: None,
             init_config: cfg,
         }
+    }
+
+    pub fn with_phoneme_map(mut self, map: Arc<PhonemeMap>) -> Self {
+        self.phoneme_map = Some(map);
+        self
     }
 
     fn process_internal(
@@ -140,7 +148,10 @@ impl TTSKoko {
         chunk_number_start: Option<usize>,
         mut mode: ExecutionMode,
     ) -> Result<Option<(Vec<f32>, Vec<WordAlignment>)>, Box<dyn std::error::Error>> {
-        let phonemizer = Phonemizer::new(lan);
+        let mut phonemizer = Phonemizer::new(lan);
+        if let Some(map) = &self.phoneme_map {
+            phonemizer = phonemizer.with_phoneme_map(Arc::clone(map));
+        }
         let chunks = self.split_text_into_chunks(txt, 500, &phonemizer);
 
         let start_chunk_num = chunk_number_start.unwrap_or(0);
@@ -383,42 +394,6 @@ impl TTSKoko {
         //    We want punctuation timestamps too, so we split words and punctuation as separate items.
         //    Simple heuristic: split on whitespace, then further split trailing/leading punctuation
         //    for .,!?;: characters.
-        fn split_words_and_punct(s: &str) -> Vec<String> {
-            let mut out = Vec::new();
-            for raw in s.split_whitespace() {
-                let chars: Vec<char> = raw.chars().collect();
-                let mut start = 0usize;
-                let mut end = chars.len();
-
-                // Leading punctuation
-                while start < end {
-                    let c = chars[start];
-                    if ".,!?:;".contains(c) {
-                        out.push(c.to_string());
-                        start += 1;
-                    } else {
-                        break;
-                    }
-                }
-                // Trailing punctuation
-                while end > start {
-                    let c = chars[end - 1];
-                    if ".,!?:;".contains(c) {
-                        end -= 1;
-                    } else {
-                        break;
-                    }
-                }
-                if start < end {
-                    out.push(chars[start..end].iter().collect());
-                }
-                // Push trailing punctuation in original order
-                for i in end..chars.len() {
-                    out.push(chars[i].to_string());
-                }
-            }
-            out
-        }
 
         let items = split_words_and_punct(text);
 
@@ -484,9 +459,17 @@ impl TTSKoko {
                 // Zero-length marker at current cursor
                 word_map.push((item.clone(), cursor, cursor));
             } else {
+                let mut word_to_record = item.clone();
+                // If it's an override, extract the word
+                if let Ok(Some(caps)) = crate::tts::phonemizer::OVERRIDE_RE.captures(item) {
+                    if let Some(word_cap) = caps.get(1) {
+                        word_to_record = word_cap.as_str().to_string();
+                    }
+                }
+
                 let start_idx = cursor;
                 let end_idx = cursor.saturating_add(cnt);
-                word_map.push((item.clone(), start_idx, end_idx));
+                word_map.push((word_to_record, start_idx, end_idx));
                 cursor = end_idx;
             }
         }
@@ -1073,8 +1056,14 @@ impl TTSKokoParallel {
             model_path: model_path.to_string(),
             models,
             styles,
+            phoneme_map: None,
             init_config: cfg,
         }
+    }
+
+    pub fn with_phoneme_map(mut self, map: Arc<PhonemeMap>) -> Self {
+        self.phoneme_map = Some(map);
+        self
     }
 
     /// Get a specific model instance for a worker
@@ -1090,6 +1079,7 @@ impl TTSKokoParallel {
             model: model_instance,
             // TODO: This clones the HashMap. In a future PR, wrap styles in Arc<>!
             styles: self.styles.clone(),
+            phoneme_map: self.phoneme_map.clone(),
             init_config: self.init_config.clone(),
         }
     }
@@ -1154,6 +1144,7 @@ impl TTSKokoParallel {
             model_path: self.model_path.clone(),
             model: Arc::clone(&self.models[0]), // Just for interface compatibility
             styles: self.styles.clone(),
+            phoneme_map: self.phoneme_map.clone(),
             init_config: self.init_config.clone(),
         };
         temp_tts.split_text_into_speech_chunks(text, max_words)
@@ -1164,5 +1155,89 @@ impl TTSKokoParallel {
         let mut voices: Vec<String> = self.styles.keys().cloned().collect();
         voices.sort();
         voices
+    }
+}
+
+fn split_words_and_punct(s: &str) -> Vec<String> {
+    use crate::tts::phonemizer::OVERRIDE_RE;
+    let mut out = Vec::new();
+
+    let mut last_match = 0;
+    for mat_res in OVERRIDE_RE.find_iter(s) {
+        if let Ok(mat) = mat_res {
+            let start = mat.start();
+            let end = mat.end();
+
+            // Process preceding text
+            if start > last_match {
+                let segment = &s[last_match..start];
+                for raw in segment.split_whitespace() {
+                    process_raw_word(raw, &mut out);
+                }
+            }
+
+            // Add the override as a single item
+            out.push(s[start..end].to_string());
+            last_match = end;
+        }
+    }
+
+    // Process remaining text
+    if last_match < s.len() {
+        let segment = &s[last_match..];
+        for raw in segment.split_whitespace() {
+            process_raw_word(raw, &mut out);
+        }
+    }
+
+    fn process_raw_word(raw: &str, out: &mut Vec<String>) {
+        let chars: Vec<char> = raw.chars().collect();
+        let mut start = 0usize;
+        let mut end = chars.len();
+
+        // Leading punctuation
+        while start < end {
+            let c = chars[start];
+            if ".,!?:;".contains(c) {
+                out.push(c.to_string());
+                start += 1;
+            } else {
+                break;
+            }
+        }
+        // Trailing punctuation
+        while end > start {
+            let c = chars[end - 1];
+            if ".,!?:;".contains(c) {
+                end -= 1;
+            } else {
+                break;
+            }
+        }
+        if start < end {
+            out.push(chars[start..end].iter().collect());
+        }
+        // Push trailing punctuation in original order
+        for i in end..chars.len() {
+            out.push(chars[i].to_string());
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_words_and_punct_with_overrides() {
+        let text = "Hello [Los Angeles](/lˈɔːs_ˈændʒələs/) city!";
+        let items = split_words_and_punct(text);
+        println!("Items: {:?}", items);
+        assert_eq!(items[0], "Hello");
+        assert_eq!(items[1], "[Los Angeles](/lˈɔːs_ˈændʒələs/)");
+        assert_eq!(items[2], "city");
+        assert_eq!(items[3], "!");
     }
 }

--- a/kokoros/src/tts/phonemizer.rs
+++ b/kokoros/src/tts/phonemizer.rs
@@ -3,13 +3,45 @@ use crate::tts::vocab::VOCAB;
 use espeak_rs::text_to_phonemes;
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
+use regex;
 use misaki_rs::G2P;
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub struct PhonemeMap {
+    pub map: HashMap<String, String>,
+    pub combined_re: Regex,
+}
+
+impl PhonemeMap {
+    pub fn new(map: HashMap<String, String>) -> Self {
+        let mut entries: Vec<_> = map.keys().collect();
+        // Sort by length descending to match longer phrases first
+        entries.sort_by(|a, b| b.len().cmp(&a.len()));
+
+        let dict_pattern = if entries.is_empty() {
+            "a^".to_string() // Matches nothing
+        } else {
+            let escaped_entries: Vec<String> = entries.iter().map(|&s| regex::escape(s)).collect();
+            format!(r"\b({})\b", escaped_entries.join("|"))
+        };
+
+        // Combine inline override and dictionary matching into a single-pass regex.
+        // Group 1 & 2: inline override word and phonemes.
+        // Group "dict": dictionary word match.
+        let combined_pattern =
+            format!(r"\[([^\]]+)\]\(/([^/]+)/\)|(?P<dict>{})", dict_pattern);
+        let combined_re = Regex::new(&combined_pattern).unwrap();
+
+        Self { map, combined_re }
+    }
+}
 
 lazy_static! {
     static ref PHONEME_PATTERNS: Regex = Regex::new(r"(?<=[a-zɹː])(?=hˈʌndɹɪd)").unwrap();
     static ref Z_PATTERN: Regex = Regex::new(r#" z(?=[;:,.!?¡¿—…"«»"" ]|$)"#).unwrap();
     static ref NINETY_PATTERN: Regex = Regex::new(r"(?<=nˈaɪn)ti(?!ː)").unwrap();
+    pub static ref OVERRIDE_RE: Regex = Regex::new(r"\[([^\]]+)\]\(/([^/]+)/\)").unwrap();
     pub static ref ESPEAK_MUTEX: Mutex<()> = Mutex::new(());
     static ref MISAKI_EN_US: G2P = G2P::new(false);
     static ref MISAKI_EN_GB: G2P = G2P::new(true);
@@ -17,13 +49,20 @@ lazy_static! {
 
 pub struct Phonemizer {
     lang: String,
+    pub phoneme_map: Option<Arc<PhonemeMap>>,
 }
 
 impl Phonemizer {
     pub fn new(lang: &str) -> Self {
         Phonemizer {
             lang: lang.to_string(),
+            phoneme_map: None,
         }
+    }
+
+    pub fn with_phoneme_map(mut self, map: Arc<PhonemeMap>) -> Self {
+        self.phoneme_map = Some(map);
+        self
     }
 
     pub fn phonemize(&self, text: &str, normalize: bool) -> String {
@@ -33,17 +72,74 @@ impl Phonemizer {
             text.to_string()
         };
 
-        let mut ps = match self.lang.as_str() {
-            "a" | "en-us" => MISAKI_EN_US.g2p(&text).0,
-            "b" | "en-gb" => MISAKI_EN_GB.g2p(&text).0,
+        let mut ps = String::new();
+        let mut last_match = 0;
+
+        // Use the combined regex if a map is present, otherwise just OVERRIDE_RE
+        let re = match &self.phoneme_map {
+            Some(map) => &map.combined_re,
+            None => &OVERRIDE_RE,
+        };
+
+        for mat_res in re.find_iter(&text) {
+            if let Ok(mat) = mat_res {
+                let start = mat.start();
+                let end = mat.end();
+
+                // Phonemize preceding plain text
+                if start > last_match {
+                    let segment = &text[last_match..start];
+                    ps.push_str(&self.phonemize_segment(segment));
+                }
+
+                let caps = re.captures(&text[start..end]).unwrap().unwrap();
+                if let Some(dict_match) = caps.name("dict") {
+                    // Dictionary match
+                    let word = dict_match.as_str();
+                    if let Some(map) = &self.phoneme_map {
+                        if let Some(phonemes) = map.map.get(word) {
+                            ps.push_str(phonemes);
+                        }
+                    }
+                } else {
+                    // Inline override match: [word](/phonemes/)
+                    // Group 1: word, Group 2: phonemes
+                    if let Some(phonemes_cap) = caps.get(2) {
+                        ps.push_str(phonemes_cap.as_str());
+                    }
+                }
+
+                last_match = end;
+            }
+        }
+
+        // Phonemize remaining plain text
+        if last_match < text.len() {
+            let segment = &text[last_match..];
+            ps.push_str(&self.phonemize_segment(segment));
+        }
+
+        self.phonemize_postprocess(ps)
+    }
+
+    fn phonemize_segment(&self, text: &str) -> String {
+        if text.trim().is_empty() {
+            return text.to_string();
+        }
+
+        match self.lang.as_str() {
+            "a" | "en-us" => MISAKI_EN_US.g2p(text).0,
+            "b" | "en-gb" => MISAKI_EN_GB.g2p(text).0,
             _ => {
                 let _guard = ESPEAK_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-                text_to_phonemes(&text, &self.lang, None, true, false)
+                text_to_phonemes(text, &self.lang, None, true, false)
                     .unwrap_or_default()
                     .join("")
             }
-        };
+        }
+    }
 
+    pub fn phonemize_postprocess(&self, mut ps: String) -> String {
         // Apply kokoro-specific replacements
         ps = ps
             .replace("kəkˈoːɹoʊ", "kˈoʊkəɹoʊ")
@@ -99,5 +195,39 @@ mod tests {
         let ps = phonemizer.phonemize("Bonjour le monde", false);
         println!("FR Phonemes: {}", ps);
         assert!(!ps.is_empty());
+    }
+
+    #[test]
+    fn test_phonemizer_overrides() {
+        let phonemizer = Phonemizer::new("en-us");
+        let ps = phonemizer.phonemize("Hello [world](/wˈɜːld/)!", false);
+        println!("Override Phonemes: {}", ps);
+        assert!(ps.contains("wˈɜːld"));
+        assert!(ps.contains("həlˈo"));
+    }
+
+    #[test]
+    fn test_phonemizer_dictionary() {
+        let mut map = HashMap::new();
+        map.insert("world".to_string(), "wˈɜːld".to_string());
+        let phoneme_map = Arc::new(PhonemeMap::new(map));
+        let phonemizer = Phonemizer::new("en-us").with_phoneme_map(phoneme_map);
+        let ps = phonemizer.phonemize("Hello world!", false);
+        println!("Dictionary Phonemes: {}", ps);
+        assert!(ps.contains("wˈɜːld"));
+        assert!(ps.contains("həlˈo"));
+    }
+
+    #[test]
+    fn test_phonemizer_nested_prevention() {
+        let mut map = HashMap::new();
+        map.insert("York".to_string(), "wrong".to_string());
+        let phoneme_map = Arc::new(PhonemeMap::new(map));
+        let phonemizer = Phonemizer::new("en-us").with_phoneme_map(phoneme_map);
+        // The inline override should take precedence and "York" inside it should NOT be replaced
+        let ps = phonemizer.phonemize("Welcome to [New York](/nˈuːjˈɔːɹk/)!", false);
+        println!("Nested Prevention Phonemes: {}", ps);
+        assert!(ps.contains("nˈuːjˈɔːɹk"));
+        assert!(!ps.contains("wrong"));
     }
 }


### PR DESCRIPTION
I have implemented the requested phoneme override feature. 

Key improvements:
- **Inline Overrides:** You can now use `hi there [Los Angeles](/lˈɔːs_ˈændʒələs/)` to manually specify phonemes.
- **Phoneme Dictionary:** A JSON dictionary can be passed via the `--dict` flag (e.g., `koko text "Hello York" --dict dict.json`).
- **Timestamp Alignment:** The alignment logic has been updated to handle these overrides correctly, ensuring that the word-level timestamps match the base word being overridden.
- **Performance & Correctness:** Used a combined regex matching approach to prevent recursive/nested replacement issues and ensure inference remains fast even with large dictionaries.

Verified with unit tests for:
- Standard phonemization.
- Inline overrides.
- Dictionary replacements.
- Nested override prevention.
- TSV alignment logic.

Fixes #3

---
*PR created automatically by Jules for task [144859276181401004](https://jules.google.com/task/144859276181401004) started by @gad2103*